### PR TITLE
Some memory savings in the Tesserae algorithm.

### DIFF
--- a/src/cortexpy/tesserae.py
+++ b/src/cortexpy/tesserae.py
@@ -39,7 +39,11 @@ class Tesserae(object):
     prho = DEFAULT_REC
     pterm = DEFAULT_TERM
 
-    def __init__(self, mem_limit=False, pdel=DEFAULT_DEL, peps=DEFAULT_EPS, prho=DEFAULT_REC, pterm=DEFAULT_TERM):
+    def __init__(
+            self, mem_limit=False,
+            pdel=DEFAULT_DEL, peps=DEFAULT_EPS,
+            prho=DEFAULT_REC, pterm=DEFAULT_TERM
+    ):
         self.pdel = pdel
         self.peps = peps
         self.prho = prho
@@ -99,14 +103,32 @@ class Tesserae(object):
         self.vt_i = np.full([2, self.nseq, self.maxl + 1], SMALL, dtype=np.float64)
         self.vt_d = np.full([2, self.nseq, self.maxl + 1], SMALL, dtype=np.float64)
 
-        self.tb_m = np.zeros([self.traceback_limit + 1, self.nseq, self.maxl + 1], dtype=np.float64)
-        self.tb_i = np.zeros([self.traceback_limit + 1, self.nseq, self.maxl + 1], dtype=np.float64)
-        self.tb_d = np.zeros([self.traceback_limit + 1, self.nseq, self.maxl + 1], dtype=np.float64)
+        self.tb_m = np.zeros(
+            [self.traceback_limit + 1, self.nseq, self.maxl + 1],
+            dtype=np.float64
+        )
+        self.tb_i = np.zeros(
+            [self.traceback_limit + 1, self.nseq, self.maxl + 1],
+            dtype=np.float64
+        )
+        self.tb_d = np.zeros(
+            [self.traceback_limit + 1, self.nseq, self.maxl + 1],
+            dtype=np.float64
+        )
 
         if self.mem_limit:
-            self.saved_vt_m = np.full([self.states_to_save + 1, self.nseq, self.maxl + 1], SMALL, dtype=np.float64)
-            self.saved_vt_i = np.full([self.states_to_save + 1, self.nseq, self.maxl + 1], SMALL, dtype=np.float64)
-            self.saved_vt_d = np.full([self.states_to_save + 1, self.nseq, self.maxl + 1], SMALL, dtype=np.float64)
+            self.saved_vt_m = np.full(
+                [self.states_to_save + 1, self.nseq, self.maxl + 1],
+                SMALL, dtype=np.float64
+            )
+            self.saved_vt_i = np.full(
+                [self.states_to_save + 1, self.nseq, self.maxl + 1],
+                SMALL, dtype=np.float64
+            )
+            self.saved_vt_d = np.full(
+                [self.states_to_save + 1, self.nseq, self.maxl + 1],
+                SMALL, dtype=np.float64
+            )
             self.saved_states = []
 
         self.maxpath_copy = np.zeros([2 * self.maxl + 1], dtype=np.uint8)
@@ -156,19 +178,30 @@ class Tesserae(object):
         lsize_l = np.log(size_l)
 
         max_r, pos_max, state_max, who_max = self.__initialization(query, targets, lsize_l)
-        max_r, pos_max, state_max, who_max = self.__recurrence(query, targets, lsize_l, l1, max_r, pos_max, state_max, who_max, store_states=self.mem_limit)
-        cp, pos_max, who_max, state_max = self.__termination(np.remainder(self.qlen, self.traceback_limit) if self.mem_limit else l1, pos_max, state_max, who_max, 2*self.maxl)
+        max_r, pos_max, state_max, who_max = self.__recurrence(
+            query, targets, lsize_l, l1, max_r, pos_max,
+            state_max, who_max, store_states=self.mem_limit
+        )
+        cp, pos_max, who_max, state_max = self.__termination(
+            np.remainder(self.qlen, self.traceback_limit) if self.mem_limit else l1,
+            pos_max, state_max, who_max, 2*self.maxl
+        )
         l2 = self.traceback_limit
         if self.mem_limit and self.saved_states:
             self.saved_states.pop()
         while self.mem_limit and self.saved_states:
             max_r, pos_max_n, state_max_n, who_max_n, pos_target_n = self.saved_states.pop()
             idx = len(self.saved_states)
-            self.vt_m[1-(idx==0)] = np.copy(self.saved_vt_m[idx])
-            self.vt_i[1-(idx==0)] = np.copy(self.saved_vt_i[idx])
-            self.vt_d[1-(idx==0)] = np.copy(self.saved_vt_d[idx])
-            self.__recurrence(query, targets, lsize_l, l2, max_r, pos_max_n, state_max_n, who_max_n, offset=pos_target_n, l0=1+(idx==0), store_states=False)
-            cp, pos_max, who_max, state_max = self.__termination(l2, pos_max, state_max, who_max, cp)
+            self.vt_m[1 - (idx == 0)] = np.copy(self.saved_vt_m[idx])
+            self.vt_i[1 - (idx == 0)] = np.copy(self.saved_vt_i[idx])
+            self.vt_d[1 - (idx == 0)] = np.copy(self.saved_vt_d[idx])
+            self.__recurrence(
+                query, targets, lsize_l, l2, max_r, pos_max_n, state_max_n,
+                who_max_n, offset=pos_target_n, l0=1 + (idx == 0), store_states=False
+            )
+            cp, pos_max, who_max, state_max = self.__termination(
+                l2, pos_max, state_max, who_max, cp
+            )
         self.__render(cp + 1, panel)
 
         return self.path
@@ -199,7 +232,8 @@ class Tesserae(object):
         pos_target = 1
         for i in range(cp, 2 * self.maxl + 1):
             if self.maxpath_state[i] == 1:
-                if seqs[0][1][pos_target - 1] == seqs[self.maxpath_copy[i] + 1][1][self.maxpath_pos[i] - 1]:
+                if seqs[0][1][pos_target - 1] == \
+                   seqs[self.maxpath_copy[i] + 1][1][self.maxpath_pos[i] - 1]:
                     sb.append("|")
                 else:
                     sb.append(" ")
@@ -276,11 +310,17 @@ class Tesserae(object):
         pos_next = 0
         while pos_target >= 1:
             if state_max == 1:
-                who_next, state_next, pos_next = self.__to_traceback_indices(self.tb_m[pos_target][who_max][pos_max])
+                who_next, state_next, pos_next = self.__to_traceback_indices(
+                    self.tb_m[pos_target][who_max][pos_max]
+                )
             elif state_max == 2:
-                who_next, state_next, pos_next = self.__to_traceback_indices(self.tb_i[pos_target][who_max][pos_max])
+                who_next, state_next, pos_next = self.__to_traceback_indices(
+                    self.tb_i[pos_target][who_max][pos_max]
+                )
             elif state_max == 3:
-                who_next, state_next, pos_next = self.__to_traceback_indices(self.tb_d[pos_target][who_max][pos_max])
+                who_next, state_next, pos_next = self.__to_traceback_indices(
+                    self.tb_d[pos_target][who_max][pos_max]
+                )
 
             cp -= 1
 
@@ -296,7 +336,10 @@ class Tesserae(object):
                 pos_target -= 1
         return cp, pos_max, who_max, state_max
 
-    def __recurrence(self, query, targets, lsize_l, l1, max_r, pos_max, state_max, who_max, offset=0, l0=2, store_states=False):
+    def __recurrence(
+            self, query, targets, lsize_l, l1, max_r, pos_max,
+            state_max, who_max, offset=0, l0=2, store_states=False
+    ):
         who_max_n = 0
         state_max_n = 0
         pos_max_n = 0
@@ -326,11 +369,16 @@ class Tesserae(object):
 
                     if vt_m_n > self.vt_m[1 - pos_target % 2][seq][pos_seq]:
                         self.vt_m[1 - pos_target % 2][seq][pos_seq] = vt_m_n
-                        self.tb_m[pos_target_trace][seq][pos_seq] = seq_10 + tb_m_n + (pos_seq - 1) / self.tb_divisor
+                        self.tb_m[pos_target_trace][seq][pos_seq] = \
+                            seq_10 + tb_m_n + (pos_seq - 1) / self.tb_divisor
 
                     # Add in state match
                     self.vt_m[1 - pos_target % 2][seq][pos_seq] += \
-                    self.lsm[convert[query[pos_target + offset - 1]]][convert[target[pos_seq - 1]]]
+                        self.lsm[
+                            convert[query[pos_target + offset - 1]]
+                        ][
+                            convert[target[pos_seq - 1]]
+                        ]
 
                     # Insert
                     self.vt_i[1 - pos_target % 2][seq][pos_seq] = vt_i_base
@@ -339,24 +387,27 @@ class Tesserae(object):
                     vt_i_n, tb_i_n = max([
                         (self.vt_m[pos_target % 2][seq][pos_seq] + self.ldel, 1),
                         (self.vt_i[pos_target % 2][seq][pos_seq] + self.leps, 2)
-                    ],key=lambda x: x[0])
+                    ], key=lambda x: x[0])
 
                     if vt_i_n > self.vt_i[1 - pos_target % 2][seq][pos_seq]:
                         self.vt_i[1 - pos_target % 2][seq][pos_seq] = vt_i_n
-                        self.tb_i[pos_target_trace][seq][pos_seq] = seq_10 + tb_i_n + pos_seq / self.tb_divisor
+                        self.tb_i[pos_target_trace][seq][pos_seq] = \
+                            seq_10 + tb_i_n + pos_seq / self.tb_divisor
 
                     # Add in state insert
-                    self.vt_i[1 - pos_target % 2][seq][pos_seq] += self.lsi[convert[query[pos_target + offset - 1]]]
+                    self.vt_i[1 - pos_target % 2][seq][pos_seq] += \
+                        self.lsi[convert[query[pos_target + offset - 1]]]
 
                     # Delete
                     if (pos_target < l1 or (self.mem_limit and not store_states)) and pos_seq > 1:
                         vt_d_n, tb_d_n = max([
                             (self.vt_m[1 - pos_target % 2][seq][pos_seq - 1] + self.ldel, 1),
                             (self.vt_d[1 - pos_target % 2][seq][pos_seq - 1] + self.leps, 3)
-                        ],key=lambda x: x[0])
+                        ], key=lambda x: x[0])
 
                         self.vt_d[1 - pos_target % 2][seq][pos_seq] = vt_d_n
-                        self.tb_d[pos_target_trace][seq][pos_seq] = seq_10 + tb_d_n + (pos_seq - 1) / self.tb_divisor
+                        self.tb_d[pos_target_trace][seq][pos_seq] = \
+                            seq_10 + tb_d_n + (pos_seq - 1) / self.tb_divisor
 
                     if self.vt_m[1 - pos_target % 2][seq][pos_seq] > max_rn:
                         max_rn = self.vt_m[1 - pos_target % 2][seq][pos_seq]
@@ -390,7 +441,6 @@ class Tesserae(object):
 
         return max_r, pos_max, state_max, who_max
 
-
     def __initialization(self, query, targets, lsize_l):
         who_max = 0
         state_max = 0
@@ -400,8 +450,10 @@ class Tesserae(object):
         seq = 0
         for target in targets:
             for pos_seq in range(1, len(target) + 1):
-                self.vt_m[0][seq][pos_seq] = self.lpiM - lsize_l + self.lsm[convert[query[0]]][convert[target[pos_seq - 1]]]
-                self.vt_i[0][seq][pos_seq] = self.lpiI - lsize_l + self.lsi[convert[query[0]]]
+                self.vt_m[0][seq][pos_seq] = self.lpiM - lsize_l + \
+                    self.lsm[convert[query[0]]][convert[target[pos_seq - 1]]]
+                self.vt_i[0][seq][pos_seq] = self.lpiI - lsize_l + \
+                    self.lsi[convert[query[0]]]
 
                 if pos_seq > 0:
                     vt_d_1, tb_d_1 = max([

--- a/src/cortexpy/tesserae.py
+++ b/src/cortexpy/tesserae.py
@@ -167,10 +167,10 @@ class Tesserae(object):
         while self.mem_limit and self.saved_states:
             max_r, pos_max_n, state_max_n, who_max_n, pos_target_n = self.saved_states.pop()
             idx = len(self.saved_states)
-            self.vt_m[1] = np.copy(self.saved_vt_m[idx])
-            self.vt_i[1] = np.copy(self.saved_vt_i[idx])
-            self.vt_d[1] = np.copy(self.saved_vt_d[idx])
-            self.__recurrence(query, panel, lsize_l, l2, max_r, pos_max_n, state_max_n, who_max_n, offset=pos_target_n, l0=1, store_states=False)
+            self.vt_m[1-(idx==0)] = np.copy(self.saved_vt_m[idx])
+            self.vt_i[1-(idx==0)] = np.copy(self.saved_vt_i[idx])
+            self.vt_d[1-(idx==0)] = np.copy(self.saved_vt_d[idx])
+            self.__recurrence(query, panel, lsize_l, l2, max_r, pos_max_n, state_max_n, who_max_n, offset=pos_target_n, l0=1+(idx==0), store_states=False)
             cp, pos_max, who_max, state_max = self.__termination(l2, pos_max, state_max, who_max, cp)
         self.__render(cp + 1, panel)
 
@@ -432,6 +432,9 @@ class Tesserae(object):
 
         if self.mem_limit:
             self.saved_states.append((max_r, pos_max, state_max, who_max, 0))
+            self.saved_vt_m[0] = np.copy(self.vt_m[0])
+            self.saved_vt_i[0] = np.copy(self.vt_i[0])
+            self.saved_vt_d[0] = np.copy(self.vt_d[0])
 
         return max_r, pos_max, state_max, who_max
 

--- a/src/cortexpy/tesserae.py
+++ b/src/cortexpy/tesserae.py
@@ -78,9 +78,9 @@ class Tesserae(object):
         self.maxl = max_length(query, targets)
         self.qlen = len(query)
 
-        self.vt_m = np.full([self.nseq, self.maxl + 1, 2], SMALL, dtype=np.float64)
-        self.vt_i = np.full([self.nseq, self.maxl + 1, 2], SMALL, dtype=np.float64)
-        self.vt_d = np.full([self.nseq, self.maxl + 1, 2], SMALL, dtype=np.float64)
+        self.vt_m = np.full([2, self.nseq, self.maxl + 1], SMALL, dtype=np.float64)
+        self.vt_i = np.full([2, self.nseq, self.maxl + 1], SMALL, dtype=np.float64)
+        self.vt_d = np.full([2, self.nseq, self.maxl + 1], SMALL, dtype=np.float64)
 
         self.tb_m = np.zeros([self.nseq, self.maxl + 1, self.qlen + 2], dtype=np.float64)
         self.tb_i = np.zeros([self.nseq, self.maxl + 1, self.qlen + 2], dtype=np.float64)
@@ -283,57 +283,57 @@ class Tesserae(object):
                     tb_base = who_max * 10 + state_max + pos_max / self.tb_divisor
                     for pos_seq in range(1, len(target) + 1):
                         # Match
-                        self.vt_m[seq][pos_seq][1 - pos_target % 2] = vt_m_base
+                        self.vt_m[1 - pos_target % 2][seq][pos_seq] = vt_m_base
                         self.tb_m[seq][pos_seq][pos_target] = tb_base
 
                         vt_m_n, tb_m_n = max([
-                            (self.vt_m[seq][pos_seq - 1][pos_target % 2] + self.lmm, 1),
-                            (self.vt_i[seq][pos_seq - 1][pos_target % 2] + self.lgm, 2),
-                            (self.vt_d[seq][pos_seq - 1][pos_target % 2] + self.ldm, 3)
+                            (self.vt_m[pos_target % 2][seq][pos_seq - 1] + self.lmm, 1),
+                            (self.vt_i[pos_target % 2][seq][pos_seq - 1] + self.lgm, 2),
+                            (self.vt_d[pos_target % 2][seq][pos_seq - 1] + self.ldm, 3)
                         ])
 
-                        if vt_m_n > self.vt_m[seq][pos_seq][1 - pos_target % 2]:
-                            self.vt_m[seq][pos_seq][1 - pos_target % 2] = vt_m_n
+                        if vt_m_n > self.vt_m[1 - pos_target % 2][seq][pos_seq]:
+                            self.vt_m[1 - pos_target % 2][seq][pos_seq] = vt_m_n
                             self.tb_m[seq][pos_seq][pos_target] = seq_10 + tb_m_n + (pos_seq - 1) / self.tb_divisor
 
                         # Add in state match
-                        self.vt_m[seq][pos_seq][1 - pos_target % 2] += \
+                        self.vt_m[1 - pos_target % 2][seq][pos_seq] += \
                             self.lsm[convert[query[pos_target - 1]]][convert[target[pos_seq - 1]]]
 
                         # Insert
-                        self.vt_i[seq][pos_seq][1 - pos_target % 2] = vt_i_base
+                        self.vt_i[1 - pos_target % 2][seq][pos_seq] = vt_i_base
                         self.tb_i[seq][pos_seq][pos_target] = tb_base
 
                         vt_i_n, tb_i_n = max([
-                            (self.vt_m[seq][pos_seq][pos_target % 2] + self.ldel, 1),
-                            (self.vt_i[seq][pos_seq][pos_target % 2] + self.leps, 2)
+                            (self.vt_m[pos_target % 2][seq][pos_seq] + self.ldel, 1),
+                            (self.vt_i[pos_target % 2][seq][pos_seq] + self.leps, 2)
                         ])
 
-                        if vt_i_n > self.vt_i[seq][pos_seq][1 - pos_target % 2]:
-                            self.vt_i[seq][pos_seq][1 - pos_target % 2] = vt_i_n
+                        if vt_i_n > self.vt_i[1 - pos_target % 2][seq][pos_seq]:
+                            self.vt_i[1 - pos_target % 2][seq][pos_seq] = vt_i_n
                             self.tb_i[seq][pos_seq][pos_target] = seq_10 + tb_i_n + pos_seq / self.tb_divisor
 
                         # Add in state insert
-                        self.vt_i[seq][pos_seq][1 - pos_target % 2] += self.lsi[convert[query[pos_target - 1]]]
+                        self.vt_i[1 - pos_target % 2][seq][pos_seq] += self.lsi[convert[query[pos_target - 1]]]
 
                         # Delete
                         if pos_target < l1 and pos_seq > 1:
                             vt_d_n, tb_d_n = max([
-                                (self.vt_m[seq][pos_seq - 1][1 - pos_target % 2] + self.ldel, 1),
-                                (self.vt_d[seq][pos_seq - 1][1 - pos_target % 2] + self.leps, 3)
+                                (self.vt_m[1 - pos_target % 2][seq][pos_seq - 1] + self.ldel, 1),
+                                (self.vt_d[1 - pos_target % 2][seq][pos_seq - 1] + self.leps, 3)
                             ])
 
-                            self.vt_d[seq][pos_seq][1 - pos_target % 2] = vt_d_n
+                            self.vt_d[1 - pos_target % 2][seq][pos_seq] = vt_d_n
                             self.tb_d[seq][pos_seq][pos_target] = seq_10 + tb_d_n + (pos_seq - 1) / self.tb_divisor
 
-                        if self.vt_m[seq][pos_seq][1 - pos_target % 2] > max_rn:
-                            max_rn = self.vt_m[seq][pos_seq][1 - pos_target % 2]
+                        if self.vt_m[1 - pos_target % 2][seq][pos_seq] > max_rn:
+                            max_rn = self.vt_m[1 - pos_target % 2][seq][pos_seq]
                             who_max_n = seq
                             state_max_n = 1
                             pos_max_n = pos_seq
 
-                        if self.vt_i[seq][pos_seq][1 - pos_target % 2] > max_rn:
-                            max_rn = self.vt_i[seq][pos_seq][1 - pos_target % 2]
+                        if self.vt_i[1 - pos_target % 2][seq][pos_seq] > max_rn:
+                            max_rn = self.vt_i[1 - pos_target % 2][seq][pos_seq]
                             who_max_n = seq
                             state_max_n = 2
                             pos_max_n = pos_seq
@@ -361,25 +361,25 @@ class Tesserae(object):
         for target in panel.values():
             if self.who_copy[seq] == 1:
                 for pos_seq in range(1, len(target) + 1):
-                    self.vt_m[seq][pos_seq][0] = self.lpiM - lsize_l + self.lsm[convert[query[0]]][convert[target[pos_seq - 1]]]
-                    self.vt_i[seq][pos_seq][0] = self.lpiI - lsize_l + self.lsi[convert[query[0]]]
+                    self.vt_m[0][seq][pos_seq] = self.lpiM - lsize_l + self.lsm[convert[query[0]]][convert[target[pos_seq - 1]]]
+                    self.vt_i[0][seq][pos_seq] = self.lpiI - lsize_l + self.lsi[convert[query[0]]]
 
                     if pos_seq > 0:
                         vt_d_1, tb_d_1 = max([
-                            (self.vt_m[seq][pos_seq - 1][0] + self.ldel, 1),
-                            (self.vt_d[seq][pos_seq - 1][0] + self.leps, 3)
+                            (self.vt_m[0][seq][pos_seq - 1] + self.ldel, 1),
+                            (self.vt_d[0][seq][pos_seq - 1] + self.leps, 3)
                         ])
-                        self.vt_d[seq][pos_seq][0] = vt_d_1
+                        self.vt_d[0][seq][pos_seq] = vt_d_1
                         self.tb_d[seq][pos_seq][0] = seq * 10 + tb_d_1 + (pos_seq - 1) / self.tb_divisor
 
-                    if self.vt_m[seq][pos_seq][0] > max_r:
-                        max_r = self.vt_m[seq][pos_seq][0]
+                    if self.vt_m[0][seq][pos_seq] > max_r:
+                        max_r = self.vt_m[0][seq][pos_seq]
                         who_max = seq
                         state_max = 1
                         pos_max = pos_seq
 
-                    if self.vt_i[seq][pos_seq][0] > max_r:
-                        max_r = self.vt_i[seq][pos_seq][0]
+                    if self.vt_i[0][seq][pos_seq] > max_r:
+                        max_r = self.vt_i[0][seq][pos_seq]
                         who_max = seq
                         state_max = 2
                         pos_max = pos_seq

--- a/src/cortexpy/tesserae.py
+++ b/src/cortexpy/tesserae.py
@@ -39,7 +39,7 @@ class Tesserae(object):
     prho = DEFAULT_REC
     pterm = DEFAULT_TERM
 
-    def __init__(self, pdel=DEFAULT_DEL, peps=DEFAULT_EPS, prho=DEFAULT_REC, pterm=DEFAULT_TERM):
+    def __init__(self, mem_limit=False, pdel=DEFAULT_DEL, peps=DEFAULT_EPS, prho=DEFAULT_REC, pterm=DEFAULT_TERM):
         self.pdel = pdel
         self.peps = peps
         self.prho = prho
@@ -72,19 +72,42 @@ class Tesserae(object):
         ]
 
         self.editTrack = []
+        self.mem_limit = mem_limit
 
     def __initialize(self, query, targets):
         self.nseq = len(targets) + 1
         self.maxl = max_length(query, targets)
         self.qlen = len(query)
 
+        if self.mem_limit:
+            qlen_sqrt = np.sqrt(self.qlen)
+            qsq_down = int(np.floor(qlen_sqrt))
+            qsq_up = int(np.ceil(qlen_sqrt))
+            # The traceback limit must be even!
+            if qsq_up % 2 == 0:
+                self.states_to_save = qsq_down
+                self.traceback_limit = qsq_up
+            else:
+                self.states_to_save = qsq_up
+                self.traceback_limit = qsq_down
+            while self.states_to_save * self.traceback_limit < self.qlen:
+                self.states_to_save += 1
+        else:
+            self.traceback_limit = self.qlen
+
         self.vt_m = np.full([2, self.nseq, self.maxl + 1], SMALL, dtype=np.float64)
         self.vt_i = np.full([2, self.nseq, self.maxl + 1], SMALL, dtype=np.float64)
         self.vt_d = np.full([2, self.nseq, self.maxl + 1], SMALL, dtype=np.float64)
 
-        self.tb_m = np.zeros([self.nseq, self.maxl + 1, self.qlen + 2], dtype=np.float64)
-        self.tb_i = np.zeros([self.nseq, self.maxl + 1, self.qlen + 2], dtype=np.float64)
-        self.tb_d = np.zeros([self.nseq, self.maxl + 1, self.qlen + 2], dtype=np.float64)
+        self.tb_m = np.zeros([self.traceback_limit + 1, self.nseq, self.maxl + 1], dtype=np.float64)
+        self.tb_i = np.zeros([self.traceback_limit + 1, self.nseq, self.maxl + 1], dtype=np.float64)
+        self.tb_d = np.zeros([self.traceback_limit + 1, self.nseq, self.maxl + 1], dtype=np.float64)
+
+        if self.mem_limit:
+            self.saved_vt_m = np.full([self.states_to_save + 1, self.nseq, self.maxl + 1], SMALL, dtype=np.float64)
+            self.saved_vt_i = np.full([self.states_to_save + 1, self.nseq, self.maxl + 1], SMALL, dtype=np.float64)
+            self.saved_vt_d = np.full([self.states_to_save + 1, self.nseq, self.maxl + 1], SMALL, dtype=np.float64)
+            self.saved_states = []
 
         self.who_copy = np.ones([self.nseq], dtype=np.int64)
         self.who_copy[0] = 0
@@ -136,8 +159,19 @@ class Tesserae(object):
         lsize_l = np.log(size_l)
 
         max_r, pos_max, state_max, who_max = self.__initialization(query, panel, lsize_l)
-        max_r, pos_max, state_max, who_max = self.__recurrence(query, panel, lsize_l, l1, max_r, pos_max, state_max, who_max)
-        cp = self.__termination(l1, pos_max, state_max, who_max)
+        max_r, pos_max, state_max, who_max = self.__recurrence(query, panel, lsize_l, l1, max_r, pos_max, state_max, who_max, store_states=self.mem_limit)
+        cp, pos_max, who_max, state_max = self.__termination(np.remainder(self.qlen, self.traceback_limit) if self.mem_limit else l1, pos_max, state_max, who_max, 2*self.maxl)
+        l2 = self.traceback_limit
+        if self.mem_limit and self.saved_states:
+            self.saved_states.pop()
+        while self.mem_limit and self.saved_states:
+            max_r, pos_max_n, state_max_n, who_max_n, pos_target_n = self.saved_states.pop()
+            idx = len(self.saved_states)
+            self.vt_m[1] = np.copy(self.saved_vt_m[idx])
+            self.vt_i[1] = np.copy(self.saved_vt_i[idx])
+            self.vt_d[1] = np.copy(self.saved_vt_d[idx])
+            self.__recurrence(query, panel, lsize_l, l2, max_r, pos_max_n, state_max_n, who_max_n, offset=pos_target_n, l0=1, store_states=False)
+            cp, pos_max, who_max, state_max = self.__termination(l2, pos_max, state_max, who_max, cp)
         self.__render(cp + 1, panel)
 
         return self.path
@@ -234,8 +268,7 @@ class Tesserae(object):
         pos = int((state_float - state) * self.tb_divisor + 1e-6)
         return who, state, pos
 
-    def __termination(self, l1, pos_max, state_max, who_max):
-        cp = 2 * self.maxl
+    def __termination(self, l1, pos_max, state_max, who_max, cp):
         self.maxpath_copy[cp] = who_max
         self.maxpath_state[cp] = state_max
         self.maxpath_pos[cp] = pos_max
@@ -246,11 +279,11 @@ class Tesserae(object):
         pos_next = 0
         while pos_target >= 1:
             if state_max == 1:
-                who_next, state_next, pos_next = self.__to_traceback_indices(self.tb_m[who_max][pos_max][pos_target])
+                who_next, state_next, pos_next = self.__to_traceback_indices(self.tb_m[pos_target][who_max][pos_max])
             elif state_max == 2:
-                who_next, state_next, pos_next = self.__to_traceback_indices(self.tb_i[who_max][pos_max][pos_target])
+                who_next, state_next, pos_next = self.__to_traceback_indices(self.tb_i[pos_target][who_max][pos_max])
             elif state_max == 3:
-                who_next, state_next, pos_next = self.__to_traceback_indices(self.tb_d[who_max][pos_max][pos_target])
+                who_next, state_next, pos_next = self.__to_traceback_indices(self.tb_d[pos_target][who_max][pos_max])
 
             cp -= 1
 
@@ -264,17 +297,20 @@ class Tesserae(object):
 
             if self.maxpath_state[cp + 1] != 3:
                 pos_target -= 1
-        return cp
+        return cp, pos_max, who_max, state_max
 
-    def __recurrence(self, query, panel, lsize_l, l1, max_r, pos_max, state_max, who_max):
+    def __recurrence(self, query, panel, lsize_l, l1, max_r, pos_max, state_max, who_max, offset=0, l0=2, store_states=False):
         who_max_n = 0
         state_max_n = 0
         pos_max_n = 0
 
-        for pos_target in range(2, l1 + 1):
+        for pos_target in range(l0, l1 + 1):
             max_rn = SMALL + max_r
             seq = 0
             seq_10 = 0
+            pos_target_trace = pos_target
+            if self.mem_limit and store_states:
+                pos_target_trace = pos_target % self.traceback_limit
 
             for target in panel.values():
                 if self.who_copy[seq] == 1:
@@ -284,47 +320,47 @@ class Tesserae(object):
                     for pos_seq in range(1, len(target) + 1):
                         # Match
                         self.vt_m[1 - pos_target % 2][seq][pos_seq] = vt_m_base
-                        self.tb_m[seq][pos_seq][pos_target] = tb_base
+                        self.tb_m[pos_target_trace][seq][pos_seq] = tb_base
 
                         vt_m_n, tb_m_n = max([
                             (self.vt_m[pos_target % 2][seq][pos_seq - 1] + self.lmm, 1),
                             (self.vt_i[pos_target % 2][seq][pos_seq - 1] + self.lgm, 2),
                             (self.vt_d[pos_target % 2][seq][pos_seq - 1] + self.ldm, 3)
-                        ])
+                        ], key=lambda x: x[0])
 
                         if vt_m_n > self.vt_m[1 - pos_target % 2][seq][pos_seq]:
                             self.vt_m[1 - pos_target % 2][seq][pos_seq] = vt_m_n
-                            self.tb_m[seq][pos_seq][pos_target] = seq_10 + tb_m_n + (pos_seq - 1) / self.tb_divisor
+                            self.tb_m[pos_target_trace][seq][pos_seq] = seq_10 + tb_m_n + (pos_seq - 1) / self.tb_divisor
 
                         # Add in state match
                         self.vt_m[1 - pos_target % 2][seq][pos_seq] += \
-                            self.lsm[convert[query[pos_target - 1]]][convert[target[pos_seq - 1]]]
+                            self.lsm[convert[query[pos_target + offset - 1]]][convert[target[pos_seq - 1]]]
 
                         # Insert
                         self.vt_i[1 - pos_target % 2][seq][pos_seq] = vt_i_base
-                        self.tb_i[seq][pos_seq][pos_target] = tb_base
+                        self.tb_i[pos_target_trace][seq][pos_seq] = tb_base
 
                         vt_i_n, tb_i_n = max([
                             (self.vt_m[pos_target % 2][seq][pos_seq] + self.ldel, 1),
                             (self.vt_i[pos_target % 2][seq][pos_seq] + self.leps, 2)
-                        ])
+                        ],key=lambda x: x[0])
 
                         if vt_i_n > self.vt_i[1 - pos_target % 2][seq][pos_seq]:
                             self.vt_i[1 - pos_target % 2][seq][pos_seq] = vt_i_n
-                            self.tb_i[seq][pos_seq][pos_target] = seq_10 + tb_i_n + pos_seq / self.tb_divisor
+                            self.tb_i[pos_target_trace][seq][pos_seq] = seq_10 + tb_i_n + pos_seq / self.tb_divisor
 
                         # Add in state insert
-                        self.vt_i[1 - pos_target % 2][seq][pos_seq] += self.lsi[convert[query[pos_target - 1]]]
+                        self.vt_i[1 - pos_target % 2][seq][pos_seq] += self.lsi[convert[query[pos_target + offset - 1]]]
 
                         # Delete
-                        if pos_target < l1 and pos_seq > 1:
+                        if (pos_target < l1 or (self.mem_limit and not store_states)) and pos_seq > 1:
                             vt_d_n, tb_d_n = max([
                                 (self.vt_m[1 - pos_target % 2][seq][pos_seq - 1] + self.ldel, 1),
                                 (self.vt_d[1 - pos_target % 2][seq][pos_seq - 1] + self.leps, 3)
-                            ])
+                            ],key=lambda x: x[0])
 
                             self.vt_d[1 - pos_target % 2][seq][pos_seq] = vt_d_n
-                            self.tb_d[seq][pos_seq][pos_target] = seq_10 + tb_d_n + (pos_seq - 1) / self.tb_divisor
+                            self.tb_d[pos_target_trace][seq][pos_seq] = seq_10 + tb_d_n + (pos_seq - 1) / self.tb_divisor
 
                         if self.vt_m[1 - pos_target % 2][seq][pos_seq] > max_rn:
                             max_rn = self.vt_m[1 - pos_target % 2][seq][pos_seq]
@@ -345,11 +381,19 @@ class Tesserae(object):
             who_max = who_max_n
             state_max = state_max_n
             pos_max = pos_max_n
+            if store_states and pos_target_trace == 0:
+                idx = len(self.saved_states)
+                self.saved_states.append((max_r, pos_max, state_max, who_max, pos_target))
+                self.saved_vt_m[idx] = np.copy(self.vt_m[1])
+                self.saved_vt_i[idx] = np.copy(self.vt_i[1])
+                self.saved_vt_d[idx] = np.copy(self.vt_d[1])
 
-        self.llk = max_r + self.lterm
-        self.combined_llk += max_r + self.lterm
+        if (self.mem_limit and store_states) or not self.mem_limit:
+            self.llk = max_r + self.lterm
+            self.combined_llk += max_r + self.lterm
 
         return max_r, pos_max, state_max, who_max
+
 
     def __initialization(self, query, panel, lsize_l):
         who_max = 0
@@ -368,9 +412,9 @@ class Tesserae(object):
                         vt_d_1, tb_d_1 = max([
                             (self.vt_m[0][seq][pos_seq - 1] + self.ldel, 1),
                             (self.vt_d[0][seq][pos_seq - 1] + self.leps, 3)
-                        ])
+                        ], key=lambda x: x[0])
                         self.vt_d[0][seq][pos_seq] = vt_d_1
-                        self.tb_d[seq][pos_seq][0] = seq * 10 + tb_d_1 + (pos_seq - 1) / self.tb_divisor
+                        self.tb_d[0][seq][pos_seq] = seq * 10 + tb_d_1 + (pos_seq - 1) / self.tb_divisor
 
                     if self.vt_m[0][seq][pos_seq] > max_r:
                         max_r = self.vt_m[0][seq][pos_seq]
@@ -385,6 +429,9 @@ class Tesserae(object):
                         pos_max = pos_seq
 
             seq += 1
+
+        if self.mem_limit:
+            self.saved_states.append((max_r, pos_max, state_max, who_max, 0))
 
         return max_r, pos_max, state_max, who_max
 

--- a/tests/test_acceptance/test_graph/test_tesserae.py
+++ b/tests/test_acceptance/test_graph/test_tesserae.py
@@ -1,5 +1,6 @@
 import random
 from random import choice
+from numpy import sqrt
 
 from cortexpy.tesserae import Tesserae
 
@@ -17,35 +18,53 @@ def repeat(string_to_expand, length):
 
 
 class TestTesseraeAcceptance:
-    def test_mosaic_alignment_on_medium_queries_and_two_templates(self):
+    def __init__(self):
         random.seed(0)
 
-        # given
+        self.samples = {}
+
         for total_len in [100, 200, 500]:
             partial_len = int(total_len / 2)
-
             query = random_dna_string(total_len)
             targets = ["".join(query[0:partial_len]) + random_dna_string(partial_len),
                        random_dna_string(partial_len) + "".join(query[partial_len:total_len])]
+            self.samples[total_len] = query, targets
 
+    def __assertions__(self, p, targets, total_len):
+        partial_len = int(total_len / 2)
+
+        assert len(p) == 3
+
+        assert p[1][0] == 'template0'
+        assert p[1][1] == "".join(targets[0][0:partial_len])
+        assert p[1][2] == 0
+        assert p[1][3] == partial_len - 1
+
+        assert p[2][0] == 'template1'
+        assert p[2][1] == repeat(" ", partial_len) + targets[1][partial_len:total_len]
+        assert p[2][2] == partial_len
+        assert p[2][3] == total_len - 1
+
+    def test_mosaic_alignment_on_medium_queries_and_two_templates(self):
+        # given
+        for total_len, (query, targets) in self.samples.items():
             # when
-            t1 = Tesserae(mem_limit=False)
-            t2 = Tesserae(mem_limit=True)
-            p = t1.align(query, targets)
-            q = t2.align(query, targets)
+            t = Tesserae(mem_limit=False)
+            p = t.align(query, targets)
 
             # then
-            assert len(p) == 3
+            self.__assertions__(p, targets, total_len)
 
-            assert p[1][0] == 'template0'
-            assert p[1][1] == "".join(targets[0][0:partial_len])
-            assert p[1][2] == 0
-            assert p[1][3] == partial_len - 1
+    def test_mosaic_alignment_on_medium_queries_and_two_templates_reduced_memory_usage(self):
+        # given
+        for total_len, (query, targets) in self.samples.items():
+            # when
+            t = Tesserae(mem_limit=True)
+            p = t.align(query, targets)
 
-            assert p[2][0] == 'template1'
-            assert p[2][1] == repeat(" ", partial_len) + targets[1][partial_len:total_len]
-            assert p[2][2] == partial_len
-            assert p[2][3] == total_len - 1
+            max_mem_limit = sqrt(total_len) + 2
 
-            assert p == q
-            assert t1.llk == t2.llk
+            # then
+            self.__assertions__(p, targets, total_len)
+            assert t.traceback_limit <= max_mem_limit
+            assert t.states_to_save <= max_mem_limit

--- a/tests/test_acceptance/test_graph/test_tesserae.py
+++ b/tests/test_acceptance/test_graph/test_tesserae.py
@@ -29,8 +29,10 @@ class TestTesseraeAcceptance:
                        random_dna_string(partial_len) + "".join(query[partial_len:total_len])]
 
             # when
-            t = Tesserae()
-            p = t.align(query, targets)
+            t1 = Tesserae(mem_limit=False)
+            t2 = Tesserae(mem_limit=True)
+            p = t1.align(query, targets)
+            q = t2.align(query, targets)
 
             # then
             assert len(p) == 3
@@ -44,3 +46,6 @@ class TestTesseraeAcceptance:
             assert p[2][1] == repeat(" ", partial_len) + targets[1][partial_len:total_len]
             assert p[2][2] == partial_len
             assert p[2][3] == total_len - 1
+
+            assert p == q
+            assert t1.llk == t2.llk

--- a/tests/test_unit/test_graph/test_tesserae.py
+++ b/tests/test_unit/test_graph/test_tesserae.py
@@ -1,30 +1,43 @@
 from cortexpy.tesserae import Tesserae
-
+from numpy import sqrt
 
 class TestTesserae:
-    def test_mosaic_alignment_on_short_query_and_two_templates(self):
+    def __init__(self):
         # given
-        query = "GTAGGCGAGATGACGCCAT"
-        targets = ["GTAGGCGAGTCCCGTTTATA", "CCACAGAAGATGACGCCATT"]
-
+        self.query = "GTAGGCGAGATGACGCCAT"
+        self.targets = ["GTAGGCGAGTCCCGTTTATA", "CCACAGAAGATGACGCCATT"]
         # when
-        t1 = Tesserae(mem_limit=False)
-        t2 = Tesserae(mem_limit=True)
-        p = t1.align(query, targets)
-        q = t2.align(query, targets)
+        self.t = Tesserae(mem_limit=False)
+        self.p = self.t.align(self.query, self.targets)
+
+    def test_mosaic_alignment_on_short_query_and_two_templates(self):
+        # then
+        assert len(self.p) == 3
+
+        assert self.p[1][0] == 'template0'
+        assert self.p[1][1] == 'GTAGGCG'
+        assert self.p[1][2] == 0
+        assert self.p[1][3] == 6
+
+        assert self.p[2][0] == 'template1'
+        assert self.p[2][1] == '       AGATGACGCCAT'
+        assert self.p[2][2] == 7
+        assert self.p[2][3] == 18
+
+        assert self.t.llk >= -27
+        assert self.t.llk <= -26
+
+    def test_mosaic_alignment_on_short_query_and_two_templates_reduced_memory_usage(self):
+        # when
+        t = Tesserae(mem_limit=True)
+        p = t.align(self.query, self.targets)
+        max_mem_limit = sqrt(len(self.query)) + 1
 
         # then
-        assert len(p) == 3
+        assert p == self.p
 
-        assert p[1][0] == 'template0'
-        assert p[1][1] == 'GTAGGCG'
-        assert p[1][2] == 0
-        assert p[1][3] == 6
+        assert t.llk >= -27
+        assert t.llk <= -26
 
-        assert p[2][0] == 'template1'
-        assert p[2][1] == '       AGATGACGCCAT'
-        assert p[2][2] == 7
-        assert p[2][3] == 18
-
-        assert p == q
-        assert t1.llk == t2.llk
+        assert t.traceback_limit <= max_mem_limit
+        assert t.states_to_save <= max_mem_limit

--- a/tests/test_unit/test_graph/test_tesserae.py
+++ b/tests/test_unit/test_graph/test_tesserae.py
@@ -1,6 +1,7 @@
 from cortexpy.tesserae import Tesserae
 from numpy import sqrt
 
+
 class TestTesserae:
     def __init__(self):
         # given

--- a/tests/test_unit/test_graph/test_tesserae.py
+++ b/tests/test_unit/test_graph/test_tesserae.py
@@ -8,8 +8,10 @@ class TestTesserae:
         targets = ["GTAGGCGAGTCCCGTTTATA", "CCACAGAAGATGACGCCATT"]
 
         # when
-        t = Tesserae()
-        p = t.align(query, targets)
+        t1 = Tesserae(mem_limit=False)
+        t2 = Tesserae(mem_limit=True)
+        p = t1.align(query, targets)
+        q = t2.align(query, targets)
 
         # then
         assert len(p) == 3
@@ -23,3 +25,6 @@ class TestTesserae:
         assert p[2][1] == '       AGATGACGCCAT'
         assert p[2][2] == 7
         assert p[2][3] == 18
+
+        assert p == q
+        assert t1.llk == t2.llk


### PR DESCRIPTION
This is an attempt to solve the issues discussed in issue #6.

In the first commit, only the values from the previous target are kept stored. This way, the memory usage is almost halved.

The later commits implements a LogSpace Algorithm, similar to [Zweig & Padmanabhan (2000)](https://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.27.7143). Where one previously needed to store a traceback of size _MN_, one now only have to store values+traceback of total size _M2√N_, where _M_ is the maximum target length (multiplied by number of targets) and _N_ is the query length.

(I hope the square-root sign '√' is visible on you monitor!)